### PR TITLE
Disable (or set to permissive) SELinux early

### DIFF
--- a/configdisk/playbooks/00-selinux.yml
+++ b/configdisk/playbooks/00-selinux.yml
@@ -1,0 +1,7 @@
+- name: "00-selinux"
+  hosts: localhost
+  tasks:
+    - name: disable selinux
+      selinux:
+        policy: targeted
+        state: "{{ 'permissive' if ansible_selinux != 'disabled' else 'disabled' }}"


### PR DESCRIPTION
Otherwise setting hostname may fail. (The hostname Ansible module fails with
"Could not get property: Connection timed out".)