### PR TITLE
Improvements of logging and diagnostics

### DIFF
--- a/rootfs/etc/init.d/azfirstboot.sh
+++ b/rootfs/etc/init.d/azfirstboot.sh
@@ -10,26 +10,74 @@ CONFIG_LABEL=${CONFIG_LABEL:-azconfig}
 CONFIG_DIR=${CONFIG_DIR:-/mnt}
 PB_DIR=${PB_DIR:-${CONFIG_DIR}/playbooks}
 CONFIG_FILE=${CONFIG_FILE:-${CONFIG_DIR}/azconfig.yml}
+LOCAL_LOG_FILE=${LOCAL_LOG_FILE:-/var/log/firstboot/status.log}
 #
+
+if [ ! -e /etc/issue.orig ]; then
+    cp -p /etc/issue /etc/issue.orig
+else
+    cp -p /etc/issue.orig /etc/issue
+fi
+
+[ ! -d $(dirname $LOCAL_LOG_FILE) ] && mkdir -p $(dirname $LOCAL_LOG_FILE)
+
+{
+    echo "Full log can be found in /root/firstboot.log"
+    echo "This summary can be found in ${LOCAL_LOG_FILE}";
+} > ${LOCAL_LOG_FILE}
+
 if mountpoint "${CONFIG_DIR}"; then
    echo "Configuration Directory is mounted"
 else
-   mount -L ${CONFIG_LABEL} ${CONFIG_DIR}
+   mount -L ${CONFIG_LABEL} ${CONFIG_DIR} || echo "Failed to mount Configuration Directory" | tee -a ${LOCAL_LOG_FILE}
 fi
 
 [ ! -d ${CONFIG_DIR}/log ] && mkdir -p ${CONFIG_DIR}/log
+
 if [ -f "${CONFIG_FILE}" -a -d ${PB_DIR} ]; then
+   errors=()
    pushd ${PB_DIR}
    for p in [0-9][0-9]-*.yml; do
-       ansible-playbook ${PB_OPTIONS} $p 2>&1 | tee ${CONFIG_DIR}/log/${p}.log
+       ansible-playbook ${PB_OPTIONS} $p 2>&1 | tee ${CONFIG_DIR}/log/${p}.log /var/log/firstboot/${p}.log
+       ansistatus=${PIPESTATUS[0]}
+       if [ ${ansistatus} -gt 0 ]; then
+           errors=( "${errors[@]}" "$p $ansistatus ${p}.log" )
+       fi
    done
    popd
-   echo "##########################################"
-   echo "# Successfully implemented all playbooks #"
-   echo "##########################################"
+
+   if test "$errors"; then
+       rm ${CONFIG_DIR}/workload_sucess_is_true
+       > ${CONFIG_DIR}/workload_sucess_is_false
+       {
+           echo "The following setup playbooks terminated with errors."
+           echo "Format: <playbook> <ansible exit code> <log file under configLUN/log and /var/log/firstboot>"
+           for i in "${errors[@]}"; do
+               echo "$i"
+           done
+           echo ;
+       } | tee -a ${LOCAL_LOG_FILE} ${CONFIG_DIR}/workload_sucess_is_false
+       rc=1
+   else
+       > ${CONFIG_DIR}/workload_sucess_is_true
+       rm ${CONFIG_DIR}/workload_sucess_is_false
+       {
+           echo "############################################"
+           echo "# Successfully applied all setup playbooks #"
+           echo "############################################"
+           echo ;
+       } | tee -a ${LOCAL_LOG_FILE} ${CONFIG_DIR}/workload_sucess_is_true
+       rc=0
+   fi
 else
-   echo "No Configuration found" | tee ${CONFIG_DIR}/log/noconfig.log
+    rm ${CONFIG_DIR}/workload_sucess_is_true
+    > ${CONFIG_DIR}/workload_sucess_is_false
+    echo "No Configuration found" | tee -a /var/log/firstboot/status.log ${CONFIG_DIR}/workload_sucess_is_false
+    rc=2
 fi
+
+cat /etc/issue.orig /var/log/firstboot/status.log > /etc/issue
 
 umount ${CONFIG_DIR}
 
+exit $rc

--- a/rootfs/etc/init.d/azfirstboot.sh
+++ b/rootfs/etc/init.d/azfirstboot.sh
@@ -6,9 +6,9 @@
 #####
 # Add playbook options here (Default -vv for debugging output)
 PB_OPTIONS=${PB_OPTIONS:-"-vv"}
-PB_DIR=${PB_DIR:-/mnt/playbooks}
 CONFIG_LABEL=${CONFIG_LABEL:-azconfig}
 CONFIG_DIR=${CONFIG_DIR:-/mnt}
+PB_DIR=${PB_DIR:-${CONFIG_DIR}/playbooks}
 CONFIG_FILE=${CONFIG_FILE:-${CONFIG_DIR}/azconfig.yml}
 #
 if awk '{print $2}' /etc/mtab | grep -q "${CONFIG_DIR}"; then

--- a/rootfs/etc/init.d/azfirstboot.sh
+++ b/rootfs/etc/init.d/azfirstboot.sh
@@ -21,7 +21,7 @@ fi
 if [ -f "${CONFIG_FILE}" -a -d ${PB_DIR} ]; then
    pushd ${PB_DIR}
    for p in [0-9][0-9]-*.yml; do
-	ansible-playbook ${PB_OPTIONS} $p 2>&1 | tee ${CONFIG_DIR}/log/${p}.log
+       ansible-playbook ${PB_OPTIONS} $p 2>&1 | tee ${CONFIG_DIR}/log/${p}.log
    done
    popd
    echo "##########################################"

--- a/rootfs/etc/init.d/azfirstboot.sh
+++ b/rootfs/etc/init.d/azfirstboot.sh
@@ -11,7 +11,7 @@ CONFIG_DIR=${CONFIG_DIR:-/mnt}
 PB_DIR=${PB_DIR:-${CONFIG_DIR}/playbooks}
 CONFIG_FILE=${CONFIG_FILE:-${CONFIG_DIR}/azconfig.yml}
 #
-if awk '{print $2}' /etc/mtab | grep -q "${CONFIG_DIR}"; then
+if mountpoint "${CONFIG_DIR}"; then
    echo "Configuration Directory is mounted"
 else
    mount -L ${CONFIG_LABEL} ${CONFIG_DIR}

--- a/rootfs/etc/systemd/system/azfirstboot.service
+++ b/rootfs/etc/systemd/system/azfirstboot.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=kickoff ansible Postinstallation tasks
-After=network.target sshd.service
-Requires=sshd.service
+After=network.target sshd.service NetworkManager-wait-online.service
+Requires=sshd.service NetworkManager-wait-online.service
 
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c 't=3; while ! nm-online -s && [ $t -gt 0 ]; do sleep 10; t=$(( --t )); done; ( /etc/init.d/azfirstboot.sh  && systemctl disable azfirstboot.service ) >> /root/firstboot.log 2>&1'
+ExecStart=/bin/bash -c '( /etc/init.d/azfirstboot.sh  && systemctl disable azfirstboot.service ) >> /root/firstboot.log 2>&1'
 ExecStop=/bin/echo "Do nothing"
 
 [Install]

--- a/rootfs/etc/systemd/system/azfirstboot.service
+++ b/rootfs/etc/systemd/system/azfirstboot.service
@@ -2,7 +2,8 @@
 Description=kickoff ansible Postinstallation tasks
 After=network.target sshd.service NetworkManager-wait-online.service
 Requires=sshd.service NetworkManager-wait-online.service
-
+Wants=getty-pre.target
+Before=getty-pre.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Write a summary into /var/log/firstboot/status.log
Create files in the config LUN according to the status
Log ansible-playbook output to /var/log/firstboot
Modify /etc/issue so that the state of the machine is immediately obvious, and do not start getty until the script has finished.
Exit the script with nonzero status in case of failure so that the service runs on the next reboot and one has a chance to fix the configuration.
And various shell and systemd cleanups.